### PR TITLE
docs: update Contributing section in main readme + patch GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - uses: denoland/setup-deno@v1
       with:
-        deno-version: ~1.28
+        deno-version: 1.28.1
     - run: deno lint
       if: matrix.os == 'ubuntu-latest'
     - run: deno fmt --check

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Deno shims for Node.js
 Commands:
 
 ```sh
+# get submodules it you did not clone them initially
+git submodule init
+git submodule update
+# upgrade or downgrade your deno binary to match deno source in packages/shim-deno/third_party/deno
+deno upgrade --version 1.28.1
 # npm install
 npm i --ignore-scripts
 # build all packages

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Commands:
 # get submodules it you did not clone them initially
 git submodule init
 git submodule update
-# upgrade or downgrade your deno binary to match deno source in packages/shim-deno/third_party/deno
+# upgrade or downgrade your deno binary to match deno source version in ./packages/shim-deno/third_party/deno
 deno upgrade --version 1.28.1
 # npm install
 npm i --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Commands:
 # get submodules it you did not clone them initially
 git submodule init
 git submodule update
-# upgrade or downgrade your deno binary to match deno source version in ./packages/shim-deno/third_party/deno
-deno upgrade --version 1.28.1
 # npm install
 npm i --ignore-scripts
 # build all packages


### PR DESCRIPTION
- Git repo having submodules are rare, in my case I did not clone submodules, and the errors received, did not help much.
- I try first with a local deno 1.29 and the build failed, I rolled back my deno to 1.28.3 to match the `startsWith('1.28')` in the code, but that failed too... so add a `deno upgrade --version 1.28.1` in the readme should help, some people.

Closes #125 

