### PR TITLE
feat: addSignalListener, removeSignalListener

### DIFF
--- a/packages/shim-deno/PROGRESS.md
+++ b/packages/shim-deno/PROGRESS.md
@@ -1,6 +1,6 @@
 # Stable Progress
 
-86%. 26 stable members to go:
+87%. 24 stable members to go:
 
 - [x] 👻 **`Addr`**
 - [ ] 👻 **`BenchDefinition`**
@@ -90,7 +90,7 @@
 - [x] 👻 **`WritePermissionDescriptor`**
 - [x] 👻 **`Writer`**
 - [x] 👻 **`WriterSync`**
-- [ ] **`addSignalListener`**
+- [x] **`addSignalListener`**
 - [x] **`args`**
 - [ ] **`bench`**
 - [x] **`build`**
@@ -172,7 +172,7 @@
 - [x] **`realPathSync`**
 - [ ] **`refTimer`**
 - [x] **`remove`**
-- [ ] **`removeSignalListener`**
+- [x] **`removeSignalListener`**
 - [x] **`removeSync`**
 - [x] **`rename`**
 - [x] **`renameSync`**

--- a/packages/shim-deno/lib/shim-deno.lib.d.ts
+++ b/packages/shim-deno/lib/shim-deno.lib.d.ts
@@ -225,6 +225,24 @@ export declare namespace Deno {
    */
   export function isatty(fd: number): boolean;
   /**
+   * Registers the given function as a listener of the given signal event.
+   *
+   * ```ts
+   * Deno.addSignalListener(
+   *   "SIGTERM",
+   *   () => {
+   *     console.log("SIGTERM!")
+   *   }
+   * );
+   * ```
+   *
+   * _Note_: On Windows only `"SIGINT"` (CTRL+C) and `"SIGBREAK"` (CTRL+Break)
+   * are supported.
+   *
+   * @category Runtime Environment
+   */
+  export function addSignalListener(signal: Signal, handler: () => void): void;
+  /**
    * Change the current working directory to the specified path.
    *
    * ```ts
@@ -1418,6 +1436,24 @@ export declare namespace Deno {
    * @category File System
    */
   export function remove(path: string | URL, options?: RemoveOptions): Promise<void>;
+  /**
+   * Removes the given signal listener that has been registered with
+   * {@linkcode Deno.addSignalListener}.
+   *
+   * ```ts
+   * const listener = () => {
+   *   console.log("SIGTERM!")
+   * };
+   * Deno.addSignalListener("SIGTERM", listener);
+   * Deno.removeSignalListener("SIGTERM", listener);
+   * ```
+   *
+   * _Note_: On Windows only `"SIGINT"` (CTRL+C) and `"SIGBREAK"` (CTRL+Break)
+   * are supported.
+   *
+   * @category Runtime Environment
+   */
+  export function removeSignalListener(signal: Signal, handler: () => void): void;
   /**
    * Synchronously removes the named file or directory.
    *
@@ -3612,40 +3648,7 @@ export declare namespace Deno {
    *
    * @category Runtime Environment
    */
-  export type Signal = | "SIGABRT"
-        | "SIGALRM"
-        | "SIGBREAK"
-        | "SIGBUS"
-        | "SIGCHLD"
-        | "SIGCONT"
-        | "SIGEMT"
-        | "SIGFPE"
-        | "SIGHUP"
-        | "SIGILL"
-        | "SIGINFO"
-        | "SIGINT"
-        | "SIGIO"
-        | "SIGKILL"
-        | "SIGPIPE"
-        | "SIGPROF"
-        | "SIGPWR"
-        | "SIGQUIT"
-        | "SIGSEGV"
-        | "SIGSTKFLT"
-        | "SIGSTOP"
-        | "SIGSYS"
-        | "SIGTERM"
-        | "SIGTRAP"
-        | "SIGTSTP"
-        | "SIGTTIN"
-        | "SIGTTOU"
-        | "SIGURG"
-        | "SIGUSR1"
-        | "SIGUSR2"
-        | "SIGVTALRM"
-        | "SIGWINCH"
-        | "SIGXCPU"
-        | "SIGXFSZ";
+  export type Signal = NodeJS.Signals & ("SIGABRT" | "SIGALRM" | "SIGBREAK" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGEMT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINFO" | "SIGINT" | "SIGIO" | "SIGKILL" | "SIGPIPE" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ");
 
   /**
    * Options that can be used with {@linkcode symlink} and

--- a/packages/shim-deno/lib/shim-deno.lib.d.ts
+++ b/packages/shim-deno/lib/shim-deno.lib.d.ts
@@ -3648,7 +3648,40 @@ export declare namespace Deno {
    *
    * @category Runtime Environment
    */
-  export type Signal = NodeJS.Signals & ("SIGABRT" | "SIGALRM" | "SIGBREAK" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGEMT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINFO" | "SIGINT" | "SIGIO" | "SIGKILL" | "SIGPIPE" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ");
+  export type Signal = | "SIGABRT"
+        | "SIGALRM"
+        | "SIGBREAK"
+        | "SIGBUS"
+        | "SIGCHLD"
+        | "SIGCONT"
+        | "SIGEMT"
+        | "SIGFPE"
+        | "SIGHUP"
+        | "SIGILL"
+        | "SIGINFO"
+        | "SIGINT"
+        | "SIGIO"
+        | "SIGKILL"
+        | "SIGPIPE"
+        | "SIGPROF"
+        | "SIGPWR"
+        | "SIGQUIT"
+        | "SIGSEGV"
+        | "SIGSTKFLT"
+        | "SIGSTOP"
+        | "SIGSYS"
+        | "SIGTERM"
+        | "SIGTRAP"
+        | "SIGTSTP"
+        | "SIGTTIN"
+        | "SIGTTOU"
+        | "SIGURG"
+        | "SIGUSR1"
+        | "SIGUSR2"
+        | "SIGVTALRM"
+        | "SIGWINCH"
+        | "SIGXCPU"
+        | "SIGXFSZ";
 
   /**
    * Options that can be used with {@linkcode symlink} and

--- a/packages/shim-deno/src/deno/stable/functions.ts
+++ b/packages/shim-deno/src/deno/stable/functions.ts
@@ -1,6 +1,7 @@
 // Command palette -> Organize imports
 
 export { isatty } from "tty";
+export { addSignalListener } from "./functions/addSignalListener.js";
 export { chdir } from "./functions/chdir.js";
 export { chmod } from "./functions/chmod.js";
 export { chmodSync } from "./functions/chmodSync.js";
@@ -60,6 +61,7 @@ export { readTextFileSync } from "./functions/readTextFileSync.js";
 export { realPath } from "./functions/realPath.js";
 export { realPathSync } from "./functions/realPathSync.js";
 export { remove } from "./functions/remove.js";
+export { removeSignalListener } from "./functions/removeSignalListener.js";
 export { removeSync } from "./functions/removeSync.js";
 export { rename } from "./functions/rename.js";
 export { renameSync } from "./functions/renameSync.js";

--- a/packages/shim-deno/src/deno/stable/functions/addSignalListener.ts
+++ b/packages/shim-deno/src/deno/stable/functions/addSignalListener.ts
@@ -1,0 +1,10 @@
+/// <reference path="../lib.deno.d.ts" />
+
+import ps from "process";
+
+export const addSignalListener: typeof Deno.addSignalListener = (
+  signal,
+  handler,
+) => {
+  ps.addListener(signal, handler);
+};

--- a/packages/shim-deno/src/deno/stable/functions/addSignalListener.ts
+++ b/packages/shim-deno/src/deno/stable/functions/addSignalListener.ts
@@ -2,9 +2,16 @@
 
 import ps from "process";
 
+function denoSignalToNodeJs(signal: Deno.Signal): NodeJS.Signals {
+  if (signal === "SIGEMT") {
+    throw new Error("SIGEMT is not supported");
+  }
+  return signal;
+}
+
 export const addSignalListener: typeof Deno.addSignalListener = (
   signal,
   handler,
 ) => {
-  ps.addListener(signal, handler);
+  ps.addListener(denoSignalToNodeJs(signal), handler);
 };

--- a/packages/shim-deno/src/deno/stable/functions/removeSignalListener.ts
+++ b/packages/shim-deno/src/deno/stable/functions/removeSignalListener.ts
@@ -1,0 +1,10 @@
+/// <reference path="../lib.deno.d.ts" />
+
+import ps from "process";
+
+export const removeSignalListener: typeof Deno.removeSignalListener = (
+  signal,
+  handler,
+) => {
+  ps.removeListener(signal, handler);
+};

--- a/packages/shim-deno/tools/denolib.ts
+++ b/packages/shim-deno/tools/denolib.ts
@@ -68,6 +68,18 @@ function processDeclsFromStable(text: string) {
     // make optional to not conflict with @types/node
     .setHasQuestionToken(true);
 
+  // only allow translating deno signals that also exist in node.js
+  // Deno.Signal := NodeJS.Signals & Deno.Signal
+  const denoSignalType = sourceFile
+    .getModuleOrThrow("Deno")
+    .getTypeAliasOrThrow("Signal");
+  const denoSignals = denoSignalType
+    .getSymbolOrThrow()
+    .getDeclaredType()
+    .getUnionTypes()
+    .map((t) => t.getText()).join(" | ");
+  denoSignalType.setType("NodeJS.Signals & (" + denoSignals + ")");
+
   // use web streams from @types/node
   [
     "ReadableStream",

--- a/packages/shim-deno/tools/denolib.ts
+++ b/packages/shim-deno/tools/denolib.ts
@@ -68,18 +68,6 @@ function processDeclsFromStable(text: string) {
     // make optional to not conflict with @types/node
     .setHasQuestionToken(true);
 
-  // only allow translating deno signals that also exist in node.js
-  // Deno.Signal := NodeJS.Signals & Deno.Signal
-  const denoSignalType = sourceFile
-    .getModuleOrThrow("Deno")
-    .getTypeAliasOrThrow("Signal");
-  const denoSignals = denoSignalType
-    .getSymbolOrThrow()
-    .getDeclaredType()
-    .getUnionTypes()
-    .map((t) => t.getText()).join(" | ");
-  denoSignalType.setType("NodeJS.Signals & (" + denoSignals + ")");
-
   // use web streams from @types/node
   [
     "ReadableStream",


### PR DESCRIPTION
I need some input on this idea.

Since Node.js and Deno have different signal types, I modified the declaration of Deno.Signal to be, essentially, `Deno.Signal & NodeJS.Signals`, preventing us from translating "Deno-only signals" to Node.js.

I tried finding out exactly which signals that mismatch, but I think that might depend on the platform/arch you built the binary on, not sure. On _my_ machine, `SIGEMT` is the only Deno signal that does not exist in Node.js. `SIGIOT`, `SIGPOLL`, `SIGUNUSED`, `SIGXFSZ`, and `SIGLOST` exist in Node.js, but not in Deno.

Additionally, in Node.js, `process.addListener` returns the NodeJS.Process object itself, whereas in Deno, `Deno.addSignalListener` returns void, so I figured it would only make sense for the translated Node.js code returns void as well.

Closes https://github.com/denoland/node_shims/issues/129