### PR TITLE
feat: implement Deno.stdin.readSync, Deno.stdout.writeSync, bugfix shims

### DIFF
--- a/packages/shim-deno/src/deno/stable/variables/std.ts
+++ b/packages/shim-deno/src/deno/stable/variables/std.ts
@@ -1,5 +1,8 @@
 ///<reference path="../lib.deno.d.ts" />
 
+import { readSync } from "../functions/readSync.js";
+import { writeSync } from "../functions/writeSync.js";
+
 function chain<T extends (...args: any[]) => Promise<any>>(
   fn: T,
   cleanup?: () => void,
@@ -45,9 +48,8 @@ export const stdin: typeof Deno.stdin = {
   get readable(): ReadableStream<Uint8Array> {
     throw new Error("Not implemented.");
   },
-  readSync() {
-    // Node.js doesn't support readSync for stdin
-    throw new Error("Not implemented.");
+  readSync(buffer: Uint8Array) {
+    return readSync(this.rid, buffer);
   },
   close() {
     process.stdin.destroy();
@@ -74,9 +76,8 @@ export const stdout: typeof Deno.stdout = {
   get writable(): WritableStream<Uint8Array> {
     throw new Error("Not implemented.");
   },
-  writeSync() {
-    // Node.js doesn't support writeSync for stdout
-    throw new Error("Not implemented");
+  writeSync(data: Uint8Array) {
+    return writeSync(this.rid, data);
   },
   close() {
     process.stdout.destroy();

--- a/packages/shim-deno/tools/run_tests.mjs
+++ b/packages/shim-deno/tools/run_tests.mjs
@@ -230,10 +230,14 @@ async function setupTests() {
   process.chdir("third_party/deno/");
 
   globalThis.Deno = (await import("../src/index.ts")).Deno;
-  globalThis.Blob = (await import("node:buffer")).Blob;
+  if (!("Blob" in globalThis)) {
+    globalThis.Blob = (await import("node:buffer")).Blob;
+  }
   await webStreamHack();
 
-  globalThis.crypto = (await import("node:crypto")).webcrypto;
+  if (!("crypto" in globalThis)) {
+    globalThis.crypto = (await import("node:crypto")).webcrypto;
+  }
 }
 
 async function webStreamHack() {


### PR DESCRIPTION
Fixes #146. I had to add some conditions to fix the tests, because otherwise I was getting the following error, I think newer node sets globalThis.crypto as a getter-only, so when it does exist in node, it'll break in this test:
```js
globalThis.crypto = (await import("node:crypto")).webcrypto;
                    ^
TypeError: Cannot set property crypto of #<Object> which has only a getter
```