### PR TITLE
fix(shim/deno): correct types

### DIFF
--- a/packages/shim-deno/lib/shim-deno.lib.d.ts
+++ b/packages/shim-deno/lib/shim-deno.lib.d.ts
@@ -3628,7 +3628,7 @@ export declare namespace Deno {
      *
      * It returns the updated offset.
      */
-    seekSync(offset: number, whence: SeekMode): number;
+    seekSync(offset: number | bigint, whence: SeekMode): number;
   }
 
   /** @category I/O */

--- a/packages/shim-deno/package.json
+++ b/packages/shim-deno/package.json
@@ -10,7 +10,7 @@
     "shim"
   ],
   "main": "./dist/index.js",
-  "types": "./lib/shim-deno.lib.d.ts",
+  "types": "./dist/index.d.ts",
   "author": "Thomas Rory Gummerson <thomas@gummerson.no> (https://trgwii.no/)",
   "contributors": [
     "Wojciech Pawlik <woj.pawlik@gmail.com>",
@@ -26,8 +26,7 @@
     "./test-internals": "./dist/deno/internal/test.js"
   },
   "files": [
-    "dist",
-    "lib/shim-deno.lib.d.ts"
+    "dist"
   ],
   "scripts": {
     "build": "npm run denolib && tsc && npm run generate-declaration-file",
@@ -35,7 +34,7 @@
     "clean": "git clean -fXde !node_modules/",
     "test": "node --loader=ts-node/esm tools/run_tests.mjs",
     "denolib": "deno run --allow-run --allow-write=src/deno tools/denolib.ts",
-    "generate-declaration-file": "deno run --allow-write=lib --allow-read tools/generateDeclarationFile.ts",
+    "generate-declaration-file": "deno run --allow-write=lib,dist --allow-read tools/generateDeclarationFile.ts",
     "update-progress": "deno run --allow-read tools/missing.ts > PROGRESS.md"
   },
   "dependencies": {

--- a/packages/shim-deno/src/deno/internal/version.ts
+++ b/packages/shim-deno/src/deno/internal/version.ts
@@ -1,2 +1,2 @@
-export const deno = "1.33.2";
-export const typescript = "5.0.3";
+export const deno = "1.33.3";
+export const typescript = "5.0.4";

--- a/packages/shim-deno/tools/generateDeclarationFile.ts
+++ b/packages/shim-deno/tools/generateDeclarationFile.ts
@@ -78,6 +78,7 @@ const sourceFile = newProject.createSourceFile(
 );
 
 sourceFile.saveSync();
+sourceFile.copyImmediatelySync(`./dist/index.d.ts`, { overwrite: true });
 
 exitIfDiagnostics(newProject, sourceFile.getPreEmitDiagnostics());
 

--- a/packages/shim-deno/tools/generateDeclarationFile.ts
+++ b/packages/shim-deno/tools/generateDeclarationFile.ts
@@ -82,6 +82,23 @@ sourceFile.copyImmediatelySync(`./dist/index.d.ts`, { overwrite: true });
 
 exitIfDiagnostics(newProject, sourceFile.getPreEmitDiagnostics());
 
+// create the internal declaration
+console.log("Generating internal test declaration file...");
+const testInternalFile = newProject.addSourceFileAtPath(
+  "src/deno/internal/test.ts",
+);
+newProject.compilerOptions.set({
+  declaration: true,
+});
+const files = newProject.emitToMemory({
+  emitOnlyDtsFiles: true,
+  targetSourceFile: testInternalFile,
+}).getFiles();
+if (files.length !== 1) {
+  throw new Error("Failed. Should have only generated one file.");
+}
+Deno.writeTextFileSync("./dist/deno/internal/test.d.ts", files[0].text);
+
 function getMainStatements() {
   const statements: StatementStructures[] = [];
 


### PR DESCRIPTION
The declaration file should be right beside the `index.js` file.

![image](https://github.com/denoland/node_shims/assets/1609021/15ce5347-643f-4553-a0b8-b2e771dba6cc)
