### PR TITLE
fix: update readSync to not provide seek / offset parameters

### DIFF
--- a/packages/shim-prompts/src/readlineSync.ts
+++ b/packages/shim-prompts/src/readlineSync.ts
@@ -7,7 +7,7 @@ export function readlineSync() {
   while (char !== "\r" && char !== "\n") {
     line += char;
     try {
-      const bytesRead = readSync(process.stdin.fd, buf, 0, 1, 0);
+      const bytesRead = readSync(process.stdin.fd, buf);
       if (bytesRead === 0) {
         return line;
       }
@@ -20,7 +20,7 @@ export function readlineSync() {
     char = String(buf);
   }
   if (char === "\r") {
-    readSync(process.stdin.fd, buf, 0, 1, 0);
+    readSync(process.stdin.fd, buf);
   }
   return line;
 }


### PR DESCRIPTION
Something in the internals of fs.readSync changed at some point, which causes the following error if you provide an offset integer to readSync while reading stdin:
`ESPIPE: invalid seek, read`
Solution is to not provide additional arguments, as [the defaults are equivalent](https://nodejs.org/api/fs.html#fsreadsyncfd-buffer-options) for this usecase.
Tested on Debian 11 and Windows 10

Closes #158