### PR TITLE
fix: match Deno version of `prompt`

### DIFF
--- a/packages/shim-prompts/src/index.ts
+++ b/packages/shim-prompts/src/index.ts
@@ -27,7 +27,7 @@ export const prompt: typeof globalThis extends { prompt: infer T } ? T
     (globalThis as any)["prompt"] ??
       function prompt(
         message = "Prompt",
-        defaultValue = undefined,
+        defaultValue,
       ) {
         writeSync(
           process.stdout.fd,

--- a/packages/shim-prompts/src/index.ts
+++ b/packages/shim-prompts/src/index.ts
@@ -32,7 +32,7 @@ export const prompt: typeof globalThis extends { prompt: infer T } ? T
         writeSync(
           process.stdout.fd,
           new TextEncoder().encode(
-            `${message}${defaultValue ? `[${defaultValue}]` : ""} `,
+            `${message}${defaultValue ? ` [${defaultValue}]` : ""} `,
           ),
         );
         const result = readlineSync();

--- a/packages/shim-prompts/src/index.ts
+++ b/packages/shim-prompts/src/index.ts
@@ -26,13 +26,13 @@ export const prompt: typeof globalThis extends { prompt: infer T } ? T
   : (message?: string, _default?: string) => string | null =
     (globalThis as any)["prompt"] ??
       function prompt(
-        message,
+        message = "Prompt",
         defaultValue = undefined,
       ) {
         writeSync(
           process.stdout.fd,
           new TextEncoder().encode(
-            `${message} ${defaultValue == null ? "" : `[${defaultValue}]`} `,
+            `${message}${defaultValue ? `[${defaultValue}]` : ""} `,
           ),
         );
         const result = readlineSync();


### PR DESCRIPTION
Removes an extra space in the prompt, adds the default `message`, and fixes the logic to match the Deno implementation.
I compared it to https://github.com/denoland/deno/blob/main/runtime/js/41_prompt.js#L33-L50, correct me if this is the wrong place please!

The main part of the Deno implementation looks like this:
https://github.com/denoland/deno/blob/a4ec7dfae01485290af91c62c1ce17a742dcb104/runtime/js/41_prompt.js#L34-L44
```ts
  defaultValue ??= null;


  if (!isatty(stdin.rid)) {
    return null;
  }


  if (defaultValue) {
    message += ` [${defaultValue}]`;
  }


  message += " ";
```
`defaultValue` is assigned to `null` if `defaultValue` is `undefined` or `null` (see [nullish coalescing assignment (??=)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment)). Then, if `defaultValue` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), ` [${defaultValue}]` is added to `message`.

I'll admit I'm quite confused why the `defaultValue ??= null;` line is needed; both `null` and `undefined` are _not_ truthy soo the `if (defaultValue) {` part works the same either way...

Anyway, the logic for this shim implementation used to look like this:
https://github.com/denoland/node_shims/blob/main/packages/shim-prompts/src/index.ts#L35
  
```ts
defaultValue == null ? "" : `[${defaultValue}]`
```

Which, if expanded to an if statement and rearranged, would look like this:

```ts
if (defaultValue != null) {
  message +=  `[${defaultValue}]`;
}
```

Because the `defaultValue ??= null;` line is not needed (see above), the difference is `defaultValue != null` in the shim vs `defaultValue` in the Deno version. Hence, I've changed it to be accurate, just checking if `defaultValue` is truthy rather than if it equals `null`.
```ts
defaultValue ? ` [${defaultValue}]` : ""
```