### PR TITLE
feat: add shim for Deno.consoleSize()

### DIFF
--- a/packages/shim-deno/lib/shim-deno.lib.d.ts
+++ b/packages/shim-deno/lib/shim-deno.lib.d.ts
@@ -272,6 +272,23 @@ export declare namespace Deno {
    * @category Network
    */
   export function connectTls(options: ConnectTlsOptions): Promise<TlsConn>;
+  /** 
+   * Gets the size of the console as columns/rows.
+   *
+   * ```ts
+   * const { columns, rows } = Deno.consoleSize();
+   * ```
+   *
+   * This returns the size of the console window as reported by the operating
+   * system. It's not a reflection of how many characters will fit within the
+   * console window, but can be used as part of that calculation.
+   *
+   * @category I/O
+   */
+  export function consoleSize(): {
+    columns: number;
+    rows: number;
+  };
   /**
    * Copies from `src` to `dst` until either EOF (`null`) is read from `src` or
    * an error occurs. It resolves to the number of bytes copied or rejects with

--- a/packages/shim-deno/src/deno/stable/functions/consoleSize.ts
+++ b/packages/shim-deno/src/deno/stable/functions/consoleSize.ts
@@ -1,0 +1,6 @@
+///<reference path="../lib.deno.d.ts" />
+
+export const consoleSize: typeof Deno.consoleSize = function consoleSize() {
+  const { columns, rows } = process.stdout;
+  return { columns, rows };
+};


### PR DESCRIPTION
Add shim for `Deno.consoleSize()`
https://deno.land/api@v1.39.0?s=Deno.consoleSize