### PR TITLE
fix: Deno.consoleSize should handle if stdout is piped

### DIFF
--- a/packages/shim-deno/src/deno/stable/functions/consoleSize.ts
+++ b/packages/shim-deno/src/deno/stable/functions/consoleSize.ts
@@ -8,6 +8,7 @@ export const consoleSize: typeof Deno.consoleSize = function consoleSize() {
       return { columns, rows };
     }
   }
-  // both stdout and stderr were piped (not the best Error, but it's what Deno does)
+  // Both stdout and stderr were piped. This is not the best error message,
+  // but it's what Deno does. Opened: https://github.com/denoland/deno/issues/22162
   throw new Error("The handle is invalid.");
 };

--- a/packages/shim-deno/src/deno/stable/functions/consoleSize.ts
+++ b/packages/shim-deno/src/deno/stable/functions/consoleSize.ts
@@ -1,6 +1,13 @@
 ///<reference path="../lib.deno.d.ts" />
 
 export const consoleSize: typeof Deno.consoleSize = function consoleSize() {
-  const { columns, rows } = process.stdout;
-  return { columns, rows };
+  const pipes = [process.stderr, process.stdout];
+  for (const pipe of pipes) {
+    if (pipe.columns != null) {
+      const { columns, rows } = pipe;
+      return { columns, rows };
+    }
+  }
+  // both stdout and stderr were piped (not the best Error, but it's what Deno does)
+  throw new Error("The handle is invalid.");
 };


### PR DESCRIPTION
Addition to https://github.com/denoland/node_shims/pull/165