### PR TITLE
refactor(BREAKING): drop Node 14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,5 @@ jobs:
     - run: npm ci --ignore-scripts
     - run: npm run --silent build --workspaces
     - run: npm run --silent test --workspaces
-    - name: Try running on Node 14
-      run: cd packages/shim-deno && npx node@14 dist/index.cjs
-      if: matrix.os == 'ubuntu-latest'
     - run: cd packages/shim-deno && tools/untested.sh
       if: matrix.os == 'ubuntu-latest'

--- a/packages/shim-deno/src/deno/stable/classes/PermissionStatus.ts
+++ b/packages/shim-deno/src/deno/stable/classes/PermissionStatus.ts
@@ -1,10 +1,5 @@
 ///<reference path="../lib.deno.d.ts" />
 
-// The listeners don't actually matter because the state of these permissions
-// is constant and mocked as Node.js has all doors open.
-
-(globalThis as any).EventTarget ??= require("events").EventTarget ?? null;
-
 export class PermissionStatus extends EventTarget
   implements Deno.PermissionStatus {
   onchange: ((this: PermissionStatus, ev: Event) => any) | null = null;

--- a/packages/shim-deno/src/deno/stable/variables/mainModule.ts
+++ b/packages/shim-deno/src/deno/stable/variables/mainModule.ts
@@ -2,13 +2,6 @@
 import { join } from "path";
 import { pathToFileURL } from "url";
 
-let mainFileName: string | undefined;
-if (typeof require === "function" && typeof module !== "undefined") {
-  mainFileName = require.main?.filename;
-} else {
-  mainFileName = process.argv[1];
-}
-
 export const mainModule: typeof Deno.mainModule = pathToFileURL(
-  mainFileName ?? join(Deno.cwd(), "$deno$repl.ts"),
+  process.argv[1] ?? join(Deno.cwd(), "$deno$repl.ts"),
 ).href;


### PR DESCRIPTION
Node 14 has been end of life for over a year and it's highly recommended to migrate away from it. If you need Node 14 support, please use `@deno/shim-deno` 0.18.2.