### PR TITLE
fix: `Deno.build.arch` should be aarch64 for aarch64

### DIFF
--- a/packages/shim-deno/src/deno/stable/variables/build.ts
+++ b/packages/shim-deno/src/deno/stable/variables/build.ts
@@ -2,8 +2,9 @@
 
 import * as os from "os";
 
+const arch = process.arch === "arm64" ? "aarch64" : "x86_64";
 export const build: typeof Deno.build = {
-  arch: "x86_64",
+  arch,
   os: ((p) => p === "win32" ? "windows" : p === "darwin" ? "darwin" : "linux")(
     os.platform(),
   ),
@@ -11,8 +12,8 @@ export const build: typeof Deno.build = {
   target:
     ((p) =>
       p === "win32"
-        ? "x86_64-pc-windows-msvc"
+        ? `${arch}-pc-windows-msvc`
         : p === "darwin"
-        ? "x86_64-apple-darwin"
-        : "x86_64-unknown-linux-gnu")(os.platform()),
+        ? `${arch}-apple-darwin`
+        : `${arch}-unknown-linux-gnu`)(os.platform()),
 };


### PR DESCRIPTION
Not perfect, but better.

Closes #152